### PR TITLE
Frends.DownloadObject method update from ListObjectsAsync() to ListObjectsV2Async()

### DIFF
--- a/Frends.AmazonS3.DownloadObject/CHANGELOG.md
+++ b/Frends.AmazonS3.DownloadObject/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [2.1.0] - 2024-12-11
+### Updated
+- Listing updated to newer version.
 ## [2.1.0] - 2023-05-10
 ### Fixed
 - Changed the way the Task handles downloaded objects to fix blank PDF files.

--- a/Frends.AmazonS3.DownloadObject/CHANGELOG.md
+++ b/Frends.AmazonS3.DownloadObject/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [2.1.0] - 2024-12-11
+## [2.2.0] - 2024-12-11
 ### Updated
 - Listing updated to newer version.
 ## [2.1.0] - 2023-05-10

--- a/Frends.AmazonS3.DownloadObject/Frends.AmazonS3.DownloadObject/DownloadObject.cs
+++ b/Frends.AmazonS3.DownloadObject/Frends.AmazonS3.DownloadObject/DownloadObject.cs
@@ -175,7 +175,7 @@ public class AmazonS3
 
             var deleted = await client.DeleteObjectAsync(deleteObjectRequest, cancellationToken);
 
-            if (deleted.DeleteMarker.Equals("true"))
+            if (deleted.DeleteMarker == "true")
                 return true;
             else
                 return false;

--- a/Frends.AmazonS3.DownloadObject/Frends.AmazonS3.DownloadObject/DownloadObject.cs
+++ b/Frends.AmazonS3.DownloadObject/Frends.AmazonS3.DownloadObject/DownloadObject.cs
@@ -175,10 +175,7 @@ public class AmazonS3
 
             var deleted = await client.DeleteObjectAsync(deleteObjectRequest, cancellationToken);
 
-            if (deleted.DeleteMarker == "true")
-                return true;
-            else
-                return false;
+            return string.IsNullOrEmpty(deleted.DeleteMarker) ? false : bool.Parse(deleted.DeleteMarker);
         }
         catch (Exception ex)
         {

--- a/Frends.AmazonS3.DownloadObject/Frends.AmazonS3.DownloadObject/DownloadObject.cs
+++ b/Frends.AmazonS3.DownloadObject/Frends.AmazonS3.DownloadObject/DownloadObject.cs
@@ -41,7 +41,18 @@ public class AmazonS3
                 var targetPath = input.S3Directory + input.SearchPattern;
                 using (AmazonS3Client client = new(input.AwsAccessKeyId, input.AwsSecretAccessKey, RegionSelection(input.Region)))
                 {
-                    var allObjectsResponse = await client.ListObjectsAsync(input.BucketName, cancellationToken);
+                    var clientRequest = new ListObjectsV2Request
+                    {
+                        BucketName = input.BucketName,
+                        Delimiter = null,
+                        Encoding = null,
+                        FetchOwner = false,
+                        MaxKeys = 10000,
+                        Prefix = string.IsNullOrWhiteSpace(input.S3Directory) ? null : input.S3Directory,
+                        StartAfter = null
+                    };
+
+                    var allObjectsResponse = await client.ListObjectsV2Async(clientRequest, cancellationToken);
                     foreach (var fileObject in allObjectsResponse.S3Objects)
                     {
                         cancellationToken.ThrowIfCancellationRequested();

--- a/Frends.AmazonS3.DownloadObject/Frends.AmazonS3.DownloadObject/DownloadObject.cs
+++ b/Frends.AmazonS3.DownloadObject/Frends.AmazonS3.DownloadObject/DownloadObject.cs
@@ -47,7 +47,7 @@ public class AmazonS3
                         Delimiter = null,
                         Encoding = null,
                         FetchOwner = false,
-                        MaxKeys = 10000,
+                        MaxKeys = 1000,
                         Prefix = string.IsNullOrWhiteSpace(input.S3Directory) ? null : input.S3Directory,
                         StartAfter = null
                     };

--- a/Frends.AmazonS3.DownloadObject/Frends.AmazonS3.DownloadObject/Frends.AmazonS3.DownloadObject.csproj
+++ b/Frends.AmazonS3.DownloadObject/Frends.AmazonS3.DownloadObject/Frends.AmazonS3.DownloadObject.csproj
@@ -22,8 +22,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.7.400.60" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.410.2" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.400.61" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.410.3" />
     <PackageReference Include="System.Runtime" Version="4.3.1" />
   </ItemGroup>
 

--- a/Frends.AmazonS3.DownloadObject/Frends.AmazonS3.DownloadObject/Frends.AmazonS3.DownloadObject.csproj
+++ b/Frends.AmazonS3.DownloadObject/Frends.AmazonS3.DownloadObject/Frends.AmazonS3.DownloadObject.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<TargetFrameworks>net6.0</TargetFrameworks>
-	<Version>2.1.0</Version>
+	<Version>2.2.0</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>
@@ -22,8 +22,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.7.10.11" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.8.23" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.400.60" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.410.2" />
     <PackageReference Include="System.Runtime" Version="4.3.1" />
   </ItemGroup>
 


### PR DESCRIPTION
The task was using ListObjectsAsync -method to list objects from the bucket before the download. This does not support directory buckets, which led to an error when the bucket type was directory.
As the fix the method was updated to ListObjectsV2Async -method instead and task libraries were updated.
Original description in the issue: https://github.com/FrendsPlatform/Frends.AmazonS3/issues/24

The DeleteSourceFile method was also updated, because of a type error in "has been deleted" check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated changelog to reflect new version 2.1.0 and enhancements in version 2.2.0.
	- Introduced new parameters in the `SingleResultObject` for improved data handling.

- **Bug Fixes**
	- Resolved issues with blank PDF files during downloads.
	- Addressed a memory leak in previous versions.

- **Improvements**
	- Enhanced configurability of S3 object listing requests.
	- Simplified logic for checking delete markers.

- **Dependencies**
	- Updated AWS SDK package versions for improved functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->