### PR TITLE
Fixed multipart upload abort logic and missing BucketName in cleanup

### DIFF
--- a/Frends.AmazonS3.UploadObject/CHANGELOG.md
+++ b/Frends.AmazonS3.UploadObject/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [3.3.0] - 2026-04-21
 ### Fixed
-- Fixed missing BucketName/Key in abort cleanup, simplified loop to a single abort call, and added throw to stop swallowing exceptions.
+- Fixed missing BucketName/Key in abort cleanup, simplified loop to a single abort call, added throw to stop swallowing exceptions and set default multipart part size to 10 MB.
 
 ## [3.2.0] - 2025-12-29
 ### Changed

--- a/Frends.AmazonS3.UploadObject/CHANGELOG.md
+++ b/Frends.AmazonS3.UploadObject/CHANGELOG.md
@@ -1,8 +1,8 @@
 ﻿# Changelog
 
-## [3.3.0] - 2025-10-17
+## [3.3.0] - 2026-04-21
 ### Fixed
--Fixed missing BucketName/Key in abort cleanup, simplified loop to a single abort call, and added throw to stop swallowing exceptions.
+- Fixed missing BucketName/Key in abort cleanup, simplified loop to a single abort call, and added throw to stop swallowing exceptions.
 
 ## [3.2.0] - 2025-12-29
 ### Changed

--- a/Frends.AmazonS3.UploadObject/CHANGELOG.md
+++ b/Frends.AmazonS3.UploadObject/CHANGELOG.md
@@ -1,5 +1,8 @@
 ﻿# Changelog
 
+## [3.3.0] - 2025-10-17
+### Fixed
+-Fixed missing BucketName/Key in abort cleanup, simplified loop to a single abort call, and added throw to stop swallowing exceptions.
 
 ## [3.2.0] - 2025-12-29
 ### Changed

--- a/Frends.AmazonS3.UploadObject/Frends.AmazonS3.UploadObject/Definitions/Connection.cs
+++ b/Frends.AmazonS3.UploadObject/Frends.AmazonS3.UploadObject/Definitions/Connection.cs
@@ -96,7 +96,8 @@ public class Connection
     /// Recommended part sizes typically range from 10 MB to 100 MB for optimal performance.
     /// </summary>
     /// <example>10</example>
-    public long PartSize { get; set; }
+    [DefaultValue(10)]
+    public long PartSize { get; set; } = 10;
 
     /// <summary>
     /// Enable/disable an AWS S3 access control list.

--- a/Frends.AmazonS3.UploadObject/Frends.AmazonS3.UploadObject/Frends.AmazonS3.UploadObject.csproj
+++ b/Frends.AmazonS3.UploadObject/Frends.AmazonS3.UploadObject/Frends.AmazonS3.UploadObject.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>3.2.0</Version>
+    <Version>3.3.0</Version>
     <Authors>Frends</Authors>
     <Copyright>Frends</Copyright>
     <Company>Frends</Company>

--- a/Frends.AmazonS3.UploadObject/Frends.AmazonS3.UploadObject/UploadObject.cs
+++ b/Frends.AmazonS3.UploadObject/Frends.AmazonS3.UploadObject/UploadObject.cs
@@ -259,7 +259,7 @@ public class AmazonS3
         }
         catch (Exception)
         {
-            if (initResponse != null)
+            try
             {
                 var abortMpuRequest = new AbortMultipartUploadRequest
                 {
@@ -270,7 +270,10 @@ public class AmazonS3
 
                 await client.AbortMultipartUploadAsync(abortMpuRequest, cancellationToken);
             }
-
+            catch
+            {
+                // Swallow abort errors so the original exception is rethrown below.
+            }
             throw;
         }
     }

--- a/Frends.AmazonS3.UploadObject/Frends.AmazonS3.UploadObject/UploadObject.cs
+++ b/Frends.AmazonS3.UploadObject/Frends.AmazonS3.UploadObject/UploadObject.cs
@@ -259,28 +259,19 @@ public class AmazonS3
         }
         catch (Exception)
         {
-            ListPartsRequest listPartsRequest = new()
+            if (initResponse != null)
             {
-                UploadId = uploadRequest.UploadId
-            };
-
-            var listParts = await client.ListPartsAsync(listPartsRequest, cancellationToken);
-
-            while (listParts.Parts.Count > 0)
-            {
-                foreach (var part in listParts.Parts)
+                var abortMpuRequest = new AbortMultipartUploadRequest
                 {
-                    AbortMultipartUploadRequest abortMpuRequest = new()
-                    {
-                        BucketName = input.BucketName,
-                        Key = path,
-                        UploadId = uploadRequest.UploadId
-                    };
-                    await client.AbortMultipartUploadAsync(abortMpuRequest, cancellationToken);
-                }
+                    BucketName = input.BucketName,
+                    Key = path,
+                    UploadId = initResponse.UploadId
+                };
 
-                listParts = await client.ListPartsAsync(listPartsRequest, cancellationToken);
+                await client.AbortMultipartUploadAsync(abortMpuRequest, cancellationToken);
             }
+
+            throw;
         }
     }
 


### PR DESCRIPTION
Please review my changes :)

# *Task Update PR template*

## Review Checklist

- [ ] Task version updated (x.x.0)
- [ ] CHANGELOG.md updated
- [ ] Solution builds
- [ ] Warnings resolved (if possible)
- [ ] Typos resolved
- [ ] Tests cover new code
- [ ] Description how to run tests locally added to README.md (if needed)
- [ ] All tests pass locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Version 3.3.0

* **Bug Fixes**
  * Corrected multipart upload abort cleanup to require bucket/key and perform a single abort call.
  * Fixed exception handling so upload errors are properly propagated instead of being suppressed.

* **Chores**
  * Set default multipart part size to 10 MB.

* **Documentation**
  * Added changelog entry for version 3.3.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->